### PR TITLE
Added Nullable Types to Typechecker, No Testing

### DIFF
--- a/interpreter.ml
+++ b/interpreter.ml
@@ -3,9 +3,9 @@ open List
 (* syntax *)
 type ident = string
 
-type typ = IntTy | NonNullClassTy of ident | NullableClassTy of ident | NullPointerTy (* The kinds of types a variable can have. *)
+type typ = IntTy | NonNullClassTy of ident | NullableClassTy of ident | NullReferenceTy (* The kinds of types a variable can have. *)
 type exp = Num of int | Add of exp * exp | Mul of exp * exp | Var of ident
-         | GetField of exp * ident | NullPointer
+         | GetField of exp * ident | NullReference
 
 type cmd = Assign of ident * exp | Seq of cmd * cmd | Skip
          | New of ident * ident * exp list

--- a/interpreter.ml
+++ b/interpreter.ml
@@ -3,9 +3,9 @@ open List
 (* syntax *)
 type ident = string
 
-type typ = IntTy | ClassTy of ident
+type typ = IntTy | NonNullClassTy of ident | NullableClassTy of ident | NullPointerTy (* The kinds of types a variable can have. *)
 type exp = Num of int | Add of exp * exp | Mul of exp * exp | Var of ident
-         | GetField of exp * ident
+         | GetField of exp * ident | NullPointer
 
 type cmd = Assign of ident * exp | Seq of cmd * cmd | Skip
          | New of ident * ident * exp list
@@ -17,7 +17,7 @@ type mdecl = { ret : typ; mname : ident; params : (typ * ident) list; body : cmd
 type cdecl = { cname : ident; super : ident; fields : (typ * ident) list; methods : mdecl list }
 
 (* contexts *)
-type ty_entry = Ty of typ
+type ty_entry = Ty of typ (* Entries in the type context can either be the types of variables, or the definitions of classes. *)
               | Class of cdecl
 
 type context = ident -> ty_entry option

--- a/typechecker-tests.ml
+++ b/typechecker-tests.ml
@@ -1,0 +1,68 @@
+(* More Test Cases *)
+
+let ctc = update (update empty_context
+    "Point" (Class {cname = "Point"; super = "Object"; fields = [(IntTy, "x"); (IntTy, "y")];
+          methods = [{ret = IntTy; mname = "getx"; params = []; body = Return (GetField (Var "this", "x"))}]}))
+    "Circle" (Class {cname = "Circle"; super = "Shape"; fields = [(NonNullClassTy "Point", "center")];
+               methods = []})
+
+let gammac = update_var ctc "circle" (NonNullClassTy "Circle")
+
+let testc : exp = (GetField (GetField (Var "circle", "center"), "x"))
+let resc = (type_of gammac testc = Some IntTy)
+(* bool = true *)
+
+
+let gamma3 : context = update_var gamma2 "s3" (NonNullClassTy "Object")
+
+let test6 : exp = (GetField (Var "s1", "side"))
+let res6 = (type_of gamma2 test6 = Some IntTy)
+(* bool = false *)
+
+let test7 : exp = (GetField (Var "s2", "side"))
+let res7 = (type_of gamma2 test7 = Some IntTy)
+(* bool = true *)
+
+let test8 : exp = (GetField (Var "s2", "id"))
+let res8 = (type_of gamma0 test8 = Some IntTy)
+(* bool = false *)
+
+let test9 : exp = (GetField (Var "s2", "id"))
+let res9 = (type_of gamma2 test9 = Some (NonNullClassTy "s2"))
+(* bool = false *)
+
+let test10 : cmd = Assign ("s1", Var "x")
+let res10 = typecheck_cmd gamma2 test10
+(* bool = false *)
+
+let test11 : cmd = Assign ("x", Var "s")
+let res11 = typecheck_cmd gamma0 test11
+(* bool = false *)
+
+let test12 : cmd = Assign ("x", Var "y")
+let res12 = typecheck_cmd gamma3 test12
+(* bool = true *)
+
+let test13 : cmd = Assign ("s2", Var "s1")
+let res13 = typecheck_cmd gamma3 test13
+(* bool = false *)
+
+let test14 : cmd = Assign ("s3", Var "s1")
+let res14 = typecheck_cmd gamma3 test14
+(* bool = true *)
+
+let test15 : cmd =
+ Seq (New ("s", "Square", [Num 0; Num 2]),
+       (* s = new Square(0, 2); *)
+       Invoke ("x", Var "s", "area", []))
+       (* s.side = s.area(); *)
+let res15 = typecheck_cmd gamma1 test15
+(* bool = true *)
+
+let test16 : cmd =
+ Seq (New ("s", "Square", [Num 0; Num 2]),
+       (* s = new Square(0, 2); *)
+       Invoke ("s", Var "s", "area", []))
+       (* s = s.area(); *)
+let res16 = typecheck_cmd gamma1 test16
+(* bool = false *)

--- a/typechecker.ml
+++ b/typechecker.ml
@@ -1,5 +1,3 @@
-(* open List *) (* Fuck off, open statements. *) (* Now that I've deleted you (and fixed the errors), the lsp properly describes lists as lists, not t.*)
-
 (* syntax *)
 type ident = string
 
@@ -62,7 +60,7 @@ let lookup_method_aux (l : mdecl list) (m : ident) : mdecl option =
 let lookup_method (ct : context) (c : ident) (m : ident) : mdecl option =
   lookup_method_aux (List.rev (methods ct c)) m
 
-let rec supers (ct : context) (c : ident) : ident list = (* Answer to problem 1*)
+let rec supers (ct : context) (c : ident) : ident list = (* Answer to problem 1 *)
   match lookup_class ct c with
   | None -> []
   | Some cd when cd.super = "Object" -> ["Object"]
@@ -72,7 +70,7 @@ let subtype (ct : context) (t1 : typ) (t2 : typ) : bool = (t1 = t2) ||
   match t1, t2 with
   | NonNullClassTy c1, NonNullClassTy c2 
   | NonNullClassTy c1, NullableClassTy c2 (* All non-nullable class types are subtypes of their corresponding nullable types, but the reverse is not true. *)
-  | NullableClassTy c1, NullableClassTy c2 -> List.exists ((=) c2) (supers ct c1) (* Haha! I have made this perhaps *too* concise! *)
+  | NullableClassTy c1, NullableClassTy c2 -> List.exists ((=) c2) (supers ct c1)
   | NullPointerTy, NullableClassTy _ -> true
   | _, _ -> false
     
@@ -84,7 +82,7 @@ let rec type_of (gamma : context) (e : exp) : typ option =
        | Some IntTy, Some IntTy -> Some IntTy
        | _, _ -> None)
   | Var x -> lookup_var gamma x  
-  | GetField (obj, f) -> (*Answer to problem 2 *)
+  | GetField (obj, f) -> (* Answer to problem 2 *)
       (match type_of gamma obj with 
        | Some NonNullClassTy c -> field_type gamma c f 
        | _ -> None)

--- a/typechecker.ml
+++ b/typechecker.ml
@@ -1,9 +1,9 @@
 (* syntax *)
 type ident = string
 
-type typ = IntTy | NonNullClassTy of ident | NullableClassTy of ident | NullPointerTy (* The kinds of types a variable can have. *)
+type typ = IntTy | NonNullClassTy of ident | NullableClassTy of ident | NullReferenceTy (* The kinds of types a variable can have. *)
 type exp = Num of int | Add of exp * exp | Mul of exp * exp | Var of ident
-         | GetField of exp * ident | NullPointer
+         | GetField of exp * ident | NullReference
 
 type cmd = Assign of ident * exp | Seq of cmd * cmd | Skip
          | New of ident * ident * exp list
@@ -71,7 +71,7 @@ let subtype (ct : context) (t1 : typ) (t2 : typ) : bool = (t1 = t2) ||
   | NonNullClassTy c1, NonNullClassTy c2 
   | NonNullClassTy c1, NullableClassTy c2 (* All non-nullable class types are subtypes of their corresponding nullable types, but the reverse is not true. *)
   | NullableClassTy c1, NullableClassTy c2 -> List.exists ((=) c2) (supers ct c1)
-  | NullPointerTy, NullableClassTy _ -> true
+  | NullReferenceTy, NullableClassTy _ -> true
   | _, _ -> false
     
 let rec type_of (gamma : context) (e : exp) : typ option =
@@ -86,7 +86,7 @@ let rec type_of (gamma : context) (e : exp) : typ option =
       (match type_of gamma obj with 
        | Some NonNullClassTy c -> field_type gamma c f 
        | _ -> None)
-  | NullPointer -> Some NullPointerTy
+  | NullReference -> Some NullReferenceTy
 ;;
 
 let typecheck (gamma : context) (e : exp) (t : typ) : bool =


### PR DESCRIPTION
You can now typecheck nullable class types! But you can't do anything with them except assign to them, and you can't use them in the interpreter.